### PR TITLE
feat: add coffee product list to home screen

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,75 +1,85 @@
 import { Image } from 'expo-image';
-import { Platform, StyleSheet } from 'react-native';
+import { FlatList, StyleSheet } from 'react-native';
 
-import { HelloWave } from '@/components/HelloWave';
-import ParallaxScrollView from '@/components/ParallaxScrollView';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
+import { useThemeColor } from '@/hooks/useThemeColor';
+
+type Product = {
+  id: string;
+  name: string;
+  price: string;
+  image: string;
+};
+
+const products: Product[] = [
+  {
+    id: '1',
+    name: 'Arabica Beans',
+    price: '$15',
+    image:
+      'https://images.unsplash.com/photo-1502741501-5c4b6cebd8c5?auto=format&fit=crop&w=800&q=60',
+  },
+  {
+    id: '2',
+    name: 'Espresso Machine',
+    price: '$200',
+    image:
+      'https://images.unsplash.com/photo-1509042239860-f550ce710b93?auto=format&fit=crop&w=800&q=60',
+  },
+  {
+    id: '3',
+    name: 'French Press',
+    price: '$25',
+    image:
+      'https://images.unsplash.com/photo-1465800872432-2460a5eeeac6?auto=format&fit=crop&w=800&q=60',
+  },
+];
+
+function ProductCard({ product }: { product: Product }) {
+  const borderColor = useThemeColor({}, 'icon');
+
+  return (
+    <ThemedView style={[styles.item, { borderColor }]}>
+      <Image source={{ uri: product.image }} style={styles.image} />
+      <ThemedText type="subtitle">{product.name}</ThemedText>
+      <ThemedText>{product.price}</ThemedText>
+    </ThemedView>
+  );
+}
 
 export default function HomeScreen() {
   return (
-    <ParallaxScrollView
-      headerBackgroundColor={{ light: '#A1CEDC', dark: '#1D3D47' }}
-      headerImage={
-        <Image
-          source={require('@/assets/images/partial-react-logo.png')}
-          style={styles.reactLogo}
-        />
-      }>
-      <ThemedView style={styles.titleContainer}>
-        <ThemedText type="title">Welcome!</ThemedText>
-        <HelloWave />
-      </ThemedView>
-      <ThemedView style={styles.stepContainer}>
-        <ThemedText type="subtitle">Step 1: Try it</ThemedText>
-        <ThemedText>
-          Edit <ThemedText type="defaultSemiBold">app/(tabs)/index.tsx</ThemedText> to see changes.
-          Press{' '}
-          <ThemedText type="defaultSemiBold">
-            {Platform.select({
-              ios: 'cmd + d',
-              android: 'cmd + m',
-              web: 'F12',
-            })}
-          </ThemedText>{' '}
-          to open developer tools.
-        </ThemedText>
-      </ThemedView>
-      <ThemedView style={styles.stepContainer}>
-        <ThemedText type="subtitle">Step 2: Explore</ThemedText>
-        <ThemedText>
-          {`Tap the Explore tab to learn more about what's included in this starter app.`}
-        </ThemedText>
-      </ThemedView>
-      <ThemedView style={styles.stepContainer}>
-        <ThemedText type="subtitle">Step 3: Get a fresh start</ThemedText>
-        <ThemedText>
-          {`When you're ready, run `}
-          <ThemedText type="defaultSemiBold">npm run reset-project</ThemedText> to get a fresh{' '}
-          <ThemedText type="defaultSemiBold">app</ThemedText> directory. This will move the current{' '}
-          <ThemedText type="defaultSemiBold">app</ThemedText> to{' '}
-          <ThemedText type="defaultSemiBold">app-example</ThemedText>.
-        </ThemedText>
-      </ThemedView>
-    </ParallaxScrollView>
+    <ThemedView style={styles.container}>
+      <FlatList
+        data={products}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => <ProductCard product={item} />}
+        contentContainerStyle={styles.listContent}
+      />
+    </ThemedView>
   );
 }
 
 const styles = StyleSheet.create({
-  titleContainer: {
-    flexDirection: 'row',
+  container: {
+    flex: 1,
+  },
+  listContent: {
+    padding: 16,
+    gap: 16,
+  },
+  item: {
     alignItems: 'center',
-    gap: 8,
+    padding: 16,
+    borderRadius: 8,
+    borderWidth: StyleSheet.hairlineWidth,
   },
-  stepContainer: {
-    gap: 8,
+  image: {
+    width: 120,
+    height: 120,
     marginBottom: 8,
-  },
-  reactLogo: {
-    height: 178,
-    width: 290,
-    bottom: 0,
-    left: 0,
-    position: 'absolute',
+    borderRadius: 8,
   },
 });
+


### PR DESCRIPTION
## Summary
- replace starter home screen with coffee product list
- show sample beans, espresso machine, and french press entries

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894299c3278833093d33c4d1dc31b5b